### PR TITLE
Adding header row management

### DIFF
--- a/examples/Examples.js
+++ b/examples/Examples.js
@@ -5,6 +5,7 @@ import {
     SubHeading,
     Pane,
     SelectMenu,
+    Checkbox,
     Button,
     Label,
     Text,
@@ -15,7 +16,7 @@ import {
 } from 'evergreen-ui';
 import saveJSON from 'save-json-file';
 
-import { Types, DropZone, mapPropsToRows } from '../src';
+import { Types, DropZone, mapColumnsToRows } from '../src';
 import CSVParser from '../src/parsers/csv';
 import XLSXParser from '../src/parsers/xlsx';
 import type { Rows, Prop, Props } from '../src/index.js.flow';
@@ -41,7 +42,8 @@ class Examples extends React.Component<ExamplesProps, ExamplesState> {
         rows: [],
         currentRowIndex: 0,
         columns: [],
-        isHoverUpload: false
+        isHoverUpload: false,
+        isIgnoreHeaderRow:true,
     };
 
     static getPropIndex(columns: Props, prop: Prop): ?number {
@@ -88,12 +90,15 @@ class Examples extends React.Component<ExamplesProps, ExamplesState> {
     };
 
     onDownload = () => {
-        const { columns, rows } = this.state;
-        saveJSON(mapPropsToRows(columns, rows));
+        const { columns, rows, isIgnoreHeaderRow } = this.state;
+        if(isIgnoreHeaderRow) {
+            rows.shift();
+        }
+        saveJSON(mapColumnsToRows(columns, rows));
     };
 
     render() {
-        const { rows, currentRowIndex, columns, isHoverUpload } = this.state;
+        const { rows, currentRowIndex, columns, isHoverUpload, isIgnoreHeaderRow } = this.state;
 
         return (
             <Container>
@@ -173,6 +178,16 @@ class Examples extends React.Component<ExamplesProps, ExamplesState> {
                                     </SelectMenu>
                                 </div>
                             ))}
+                            <Checkbox
+                                height="20"
+                                checked={isIgnoreHeaderRow}
+                                appearance="default"
+                                hasCheckIcon={true}
+                                label="Ignore header row"
+                                onChange={ () => this.setState({isIgnoreHeaderRow:!isIgnoreHeaderRow})}
+                            >
+                                </Checkbox>
+
                             <Button
                                 appearance="green"
                                 onClick={this.onDownload}

--- a/examples/Examples.js
+++ b/examples/Examples.js
@@ -43,7 +43,7 @@ class Examples extends React.Component<ExamplesProps, ExamplesState> {
         currentRowIndex: 0,
         columns: [],
         isHoverUpload: false,
-        isIgnoreHeaderRow:true,
+        isIgnoreHeaderRow: true
     };
 
     static getPropIndex(columns: Props, prop: Prop): ?number {
@@ -90,15 +90,26 @@ class Examples extends React.Component<ExamplesProps, ExamplesState> {
     };
 
     onDownload = () => {
-        const { columns, rows, isIgnoreHeaderRow } = this.state;
-        if(isIgnoreHeaderRow) {
-            rows.shift();
-        }
+        const { columns, isIgnoreHeaderRow } = this.state;
+        const rows = isIgnoreHeaderRow ? this.state.rows.slice(1) : this.state.rows;
+
         saveJSON(mapColumnsToRows(columns, rows));
     };
 
+    onToggleIgnoreHeaderRow = () => {
+        this.setState(({ isIgnoreHeaderRow }) => ({
+            isIgnoreHeaderRow: !isIgnoreHeaderRow
+        }));
+    };
+
     render() {
-        const { rows, currentRowIndex, columns, isHoverUpload, isIgnoreHeaderRow } = this.state;
+        const {
+            rows,
+            currentRowIndex,
+            columns,
+            isHoverUpload,
+            isIgnoreHeaderRow
+        } = this.state;
 
         return (
             <Container>
@@ -111,10 +122,10 @@ class Examples extends React.Component<ExamplesProps, ExamplesState> {
 
                 {rows.length > 0 ? (
                     <Pane elevation={0} padding={20} display="flex">
-                        <div style={{ width: '60%', overflowX: 'auto' }}>
+                        <div style={{ width: '75%', overflowX: 'auto' }}>
                             <Table width="max-content">
-                                <TableBody>
-                                    {rows.slice(0, 10).map((row, rowIndex) => (
+                                <TableBody height={360}>
+                                    {rows.slice(0, 20).map((row, rowIndex) => (
                                         <TableRow
                                             key={rowIndex}
                                             onSelect={() =>
@@ -126,12 +137,30 @@ class Examples extends React.Component<ExamplesProps, ExamplesState> {
                                             isSelectable
                                         >
                                             {row.map((cell, cellIndex) => (
-                                                <TextTableCell key={cellIndex}>
+                                                <TextTableCell
+                                                    key={cellIndex}
+                                                    borderRight={
+                                                        row.length - 1 ===
+                                                        cellIndex
+                                                            ? null
+                                                            : true
+                                                    }
+                                                >
                                                     {cell}
                                                 </TextTableCell>
                                             ))}
                                         </TableRow>
                                     ))}
+                                    {rows.length > 20 ? (
+                                        <TableRow key="moreRow">
+                                            <TextTableCell key="moreCell">
+                                                <b>{rows.length - 20}</b>{' '}
+                                                additionnal rows where found...
+                                            </TextTableCell>
+                                        </TableRow>
+                                    ) : (
+                                        ''
+                                    )}
                                 </TableBody>
                             </Table>
                         </div>
@@ -166,7 +195,7 @@ class Examples extends React.Component<ExamplesProps, ExamplesState> {
                                             {Examples.getPropIndex(
                                                 columns,
                                                 prop
-                                            ) == null
+                                            ) === null
                                                 ? 'Select a value...'
                                                 : rows[currentRowIndex][
                                                       Examples.getPropIndex(
@@ -182,11 +211,10 @@ class Examples extends React.Component<ExamplesProps, ExamplesState> {
                                 height="20"
                                 checked={isIgnoreHeaderRow}
                                 appearance="default"
-                                hasCheckIcon={true}
+                                hasCheckIcon
                                 label="Ignore header row"
-                                onChange={ () => this.setState({isIgnoreHeaderRow:!isIgnoreHeaderRow})}
-                            >
-                                </Checkbox>
+                                onChange={this.onToggleIgnoreHeaderRow}
+                            />
 
                             <Button
                                 appearance="green"

--- a/src/Types.js
+++ b/src/Types.js
@@ -19,7 +19,7 @@ class Types {
     }
 
     static String() {
-        return new Types(value => String(value));
+        return new Types(value => value === null ? null : String(value));
     }
 
     static Number() {
@@ -30,7 +30,7 @@ class Types {
     }
 
     static Boolean() {
-        return new Types(value => Boolean(value));
+        return new Types(value => value === null ? null : Boolean(value));
     }
 
     static Email() {

--- a/src/__tests__/mapColumnsToRows.js
+++ b/src/__tests__/mapColumnsToRows.js
@@ -123,12 +123,7 @@ test('it should serialize value to date', t => {
     const columns = Types.Object({
         date: Types.Date().alias('Date')
     });
-    const rows = [
-        ['2005-08-27'],
-        ['not a date'],
-        [false],
-        [1125100800000]
-    ];
+    const rows = [['2005-08-27'], ['not a date'], [false], [1125100800000]];
     const actual = mapColumnsToRows(columns, rows);
     const expected = [
         {

--- a/src/parsers/xlsx.js
+++ b/src/parsers/xlsx.js
@@ -13,7 +13,7 @@ export default {
                 const data = new Uint8Array(event.target.result);
                 const workbook = XLSX.read(data, { type: 'array' });
                 const sheet = workbook.Sheets[workbook.SheetNames[0]];
-                const rows = XLSX.utils.sheet_to_json(sheet);
+                const rows = XLSX.utils.sheet_to_json(sheet, {header:1, blankrows:false, defval:null});
                 const maxCells = rows.reduce((max, row) => {
                     const cells = Object.keys(row).length;
                     return cells > max ? cells : max;

--- a/src/parsers/xlsx.js
+++ b/src/parsers/xlsx.js
@@ -13,7 +13,11 @@ export default {
                 const data = new Uint8Array(event.target.result);
                 const workbook = XLSX.read(data, { type: 'array' });
                 const sheet = workbook.Sheets[workbook.SheetNames[0]];
-                const rows = XLSX.utils.sheet_to_json(sheet, {header:1, blankrows:false, defval:null});
+                const rows = XLSX.utils.sheet_to_json(sheet, {
+                    header: 1,
+                    blankrows: false,
+                    defval: null
+                });
                 const maxCells = rows.reduce((max, row) => {
                     const cells = Object.keys(row).length;
                     return cells > max ? cells : max;


### PR DESCRIPTION
I've added a checkbox to exclude by default the header column while still been able to use it in the column mapping.

+ Small typo fix on "mapPropsToRows" -> change to "mapColumnsToRows"